### PR TITLE
change entrypoint to command to enable py.test to be executed.

### DIFF
--- a/create_aio_app/template/{{cookiecutter.project_name}}/docker-compose.yml
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/docker-compose.yml
@@ -57,4 +57,4 @@ services:
     container_name: {{ cookiecutter.project_name }}_test
     ports:
       - 8082:8082
-    entrypoint: py.test -v -p no:warnings
+    command: py.test -v -p no:warnings


### PR DESCRIPTION
This fixes the issue where tests were not being executed.
and after `make test` is executed  the tests are not executed and the following is the output
```bash
test_1             | ============================ no tests ran in 0.02s =============================
test_1             | ERROR: file not found: make
```


